### PR TITLE
Remove comments around CFBundleShortVersionString

### DIFF
--- a/src/main/resources/Info.plist
+++ b/src/main/resources/Info.plist
@@ -16,8 +16,8 @@
 	<string>Transkribus</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<!--<key>CFBundleShortVersionString</key>
-	<string>${project.version}</string>-->
+	<key>CFBundleShortVersionString</key>
+	<string>${project.version}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
CFBundleShortVersionString was commented out. This causes a problem
when tools like [munki](https://github.com/munki/munki) are used to deploy the software on multiple machines.

Munki uses the information found in CFBundleShortVersionString to decide whether or not a
computer is running the latest version of a given software. A valid entry is therefore required.